### PR TITLE
[BUGFIX] Ignore non-PHP controller class files

### DIFF
--- a/Classes/Information/ExtensionInformation.php
+++ b/Classes/Information/ExtensionInformation.php
@@ -216,7 +216,17 @@ class ExtensionInformation
             if ($file === '..') {
                 continue;
             }
-            $controllerClasses[] = pathinfo($file, PATHINFO_FILENAME);
+            // Only include files that end with "Controller.php"
+            if (!str_ends_with($file, 'Controller.php')) {
+                continue;
+            }
+
+            $className = pathinfo($file, PATHINFO_FILENAME);
+
+            // Must be a valid PHP class name and not start with "_"
+            if (preg_match('/^[A-Za-z]w*$/', $className)) {
+                $controllerClasses[] = $className;
+            }
         }
 
         sort($controllerClasses);


### PR DESCRIPTION
If a legacy controller is temporarily renamed (e.g. `MyController.php.inc`), the Kickstarter still tried to load it and then failed. This change limits discovered controllers to proper PHP class filenames that end with `Controller.php` and start with a letter (no leading `_`), preventing such errors.

Resolves: https://github.com/FriendsOfTYPO3/kickstarter/issues/160